### PR TITLE
fix:update merge time as review time if review not done

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -202,7 +202,10 @@ export const formatPullRequest = (
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       firstCommitAt: new Date(firstCommit!.authoredDate),
       openedAt: new Date(pullRequest.createdAt),
-      firstReviewedAt: new Date(pullRequest.reviews?.nodes?.[0]?.createdAt),
+      // レビューなしでマージされている場合は、Approveをレビューとみなす
+      firstReviewedAt: new Date(
+        pullRequest.reviews?.nodes?.[0]?.createdAt ?? pullRequest.mergedAt
+      ),
       mergedAt: new Date(pullRequest.mergedAt),
       timeUnit,
     });
@@ -243,7 +246,7 @@ export const formatPullRequest = (
   });
 };
 
-const calcLeadTime = ({
+export const calcLeadTime = ({
   firstCommitAt,
   openedAt,
   firstReviewedAt,


### PR DESCRIPTION
 If no review, firstReviewedAt was undefined and Lead time calculation resulted in NaN. Modified to assume approval as review
 and replace firstReviewedAt with MergedAt when no review.

✅ Closes: #12
